### PR TITLE
mcp: omit static knowledge from ordinary compact deltas

### DIFF
--- a/lib/neonethack/mcp/compact.ts
+++ b/lib/neonethack/mcp/compact.ts
@@ -23,8 +23,19 @@ export class CompactResponses {
     const before = old.observation, after = result.observation;
     const observation: Record<string, any> = {};
     const remove = Object.keys(before).filter(key => !(key in after));
+    const equal = (field: string, left: any, right: any) => {
+      // knowledge carries observedTurn, which advances on every ordinary turn;
+      // compare the disclosed content without that marker so a static block is
+      // not re-sent in full each delta. The baseline keeps the last knowledge;
+      // perception.knowledge and knowledge.observedTurn signal currency.
+      if (field === "knowledge" && left && right && typeof left === "object" && typeof right === "object") {
+        left = { ...left }; delete left.observedTurn;
+        right = { ...right }; delete right.observedTurn;
+      }
+      return JSON.stringify(left) === JSON.stringify(right);
+    };
     for (const [key, value] of Object.entries(after)) {
-      if (key !== "world" && JSON.stringify(value) !== JSON.stringify(before[key])) observation[key] = value;
+      if (key !== "world" && !equal(key, value, before[key])) observation[key] = value;
     }
     const key = (cell: any) => `${cell.x},${cell.y}`;
     const cells = new Map(before.world.map((cell: any) => [key(cell), cell]));

--- a/lib/neonethack/tests/compact-knowledge.test.mjs
+++ b/lib/neonethack/tests/compact-knowledge.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CompactResponses, CompactObservationReader } from "../dist/mcp/compact.js";
+
+// knowledge carries observedTurn, which advances every ordinary turn; a delta
+// must not re-send the whole block when only that marker moved.
+const knowledge = (observedTurn, kills) => ({
+  observedTurn,
+  skills: [
+    { id: "skill-1", name: "dagger", level: "Basic", advancement: "practice" },
+    { id: "skill-17", name: "spear", level: "Basic", advancement: "practice" },
+    { id: "skill-28", name: "attack spells", level: "Unskilled", advancement: "practice" },
+  ],
+  conduct: { kills, weaponHits: kills, food: 0, wishes: 0, pets: 1 },
+  spells: [],
+  levels: [{ branch: "The Dungeons of Doom", depth: 1, id: "level-0-1", freshness: "remembered", features: {} }],
+  achievements: [],
+});
+
+const frame = (revision, turn, k) => ({
+  version: 1, sessionId: "a", revision,
+  observation: {
+    location: { id: "level-0-1" },
+    turn,
+    you: { x: 5, y: 5 },
+    vitals: { turn, health: 16 },
+    knowledge: k,
+    world: [{ x: 5, y: 5, terrain: { type: "floor" } }],
+  },
+});
+
+test("ordinary deltas omit knowledge when only its observedTurn advanced", () => {
+  const compact = new CompactResponses(), reader = new CompactObservationReader();
+  reader.apply(compact.project(frame(1, 1, knowledge(1, 1)), "session.create"));
+  const next = compact.project(frame(2, 2, knowledge(2, 1)), "game.move");
+  assert.equal(next.update.kind, "delta");
+  assert.equal(next.observation.knowledge, undefined, "static knowledge must not ride along the delta");
+  const materialized = reader.apply(next);
+  assert.equal(materialized.observation.turn, 2);
+  assert.equal(materialized.observation.knowledge.observedTurn, 1, "baseline knowledge is retained");
+  assert.equal(materialized.observation.knowledge.conduct.kills, 1);
+});
+
+test("deltas still disclose knowledge when its content changes", () => {
+  const compact = new CompactResponses(), reader = new CompactObservationReader();
+  reader.apply(compact.project(frame(1, 1, knowledge(1, 1)), "session.create"));
+  const next = compact.project(frame(2, 2, knowledge(2, 2)), "game.move");
+  assert.equal(next.update.kind, "delta");
+  assert.deepEqual(next.observation.knowledge, knowledge(2, 2));
+  const materialized = reader.apply(next);
+  assert.equal(materialized.observation.knowledge.observedTurn, 2);
+  assert.equal(materialized.observation.knowledge.conduct.kills, 2);
+});
+
+test("content changes after an omission are still disclosed and replace the baseline", () => {
+  const compact = new CompactResponses(), reader = new CompactObservationReader();
+  reader.apply(compact.project(frame(1, 1, knowledge(1, 1)), "session.create"));
+  reader.apply(compact.project(frame(2, 2, knowledge(2, 1)), "game.move"));
+  const next = compact.project(frame(3, 3, knowledge(3, 4)), "game.move");
+  assert.deepEqual(next.observation.knowledge, knowledge(3, 4), "changed content must be emitted");
+  const materialized = reader.apply(next);
+  assert.equal(materialized.observation.knowledge.observedTurn, 3);
+  assert.equal(materialized.observation.knowledge.conduct.kills, 4);
+});


### PR DESCRIPTION
## Problem

`CompactResponses.project()` (used by WebMCP and both stdio MCP servers) builds
deltas by comparing each top-level observation field with `JSON.stringify`. The
`knowledge` field carries `observedTurn`, which advances on **every** ordinary
turn, so a fully static block (skills, conduct, achievements, remembered levels,
spells) is re-sent in full on each delta even when none of its content changed.

Observed on the live client: turns 159–188 with zero knowledge changes (no
kills, no skill/level/achievement events) still shipped the entire ~22-row
skills array plus conduct/achievements/levels on every move — the largest
repeated payload in ordinary turn responses, defeating the compact-delta
presentation.

## Fix

In `CompactResponses.project()`, compare `knowledge` content without its
`observedTurn` marker. When only that marker moved, the field is omitted from
the delta and the baseline keeps the last knowledge block. Currency remains
readable via `observation.perception.knowledge` and `knowledge.observedTurn`,
as already documented; `CompactObservationReader` merges whole-field
replacement and needs no change.

Content changes (kills, skill rank, new achievement, …) still emit the full
`knowledge` block as before.

## Tests

`tests/compact-knowledge.test.mjs` (new, `node --test`, no engine or network):

- ordinary delta omits `knowledge` when only `observedTurn` advanced, and the
  materialized observation retains the baseline block;
- a real content change still emits the full `knowledge` block;
- a content change *after* an omission is still disclosed and replaces the
  baseline.

Verified locally: `tsc -p tsconfig.json` clean; `node --test
tests/compact-knowledge.test.mjs tests/browser-imports.test.mjs` → 5 pass.
